### PR TITLE
Integrate share buttons throughout research report

### DIFF
--- a/src/app/components/research-report/beyond-financial-sustainability.tsx
+++ b/src/app/components/research-report/beyond-financial-sustainability.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { QuoteCards } from "./_components/quotes";
+import { SimpleShareButton } from "@/app/components/share-mode/simple-share-button";
 
 export const BeyondFinancialSustainability = () => {
   return (
@@ -18,7 +19,7 @@ export const BeyondFinancialSustainability = () => {
           text='Despite expressing uncertainty about their roles, contributors are optimistic about the sustainability of Bitcoin and their individual
             career prospects in the wider ecosystem. Yet, this abundance mindset may mask a critical vulnerability: the prevailing two-year tenure in
             grant-funded roles quietly drains protocol expertise, as knowledge leaves with each departure and turnover outpaces the accumulation of
-            long-term experience.'
+            long-term experience. <SimpleShareButton shareId="ecosystem-replacement" />'
         />
 
         <div className='grid grid-cols-1 md:grid-cols-2 items-center gap-6 flex-wrap justify-between'>
@@ -127,7 +128,7 @@ export const BeyondFinancialSustainability = () => {
         <TakeawayCard
           text='The one-size-fits-all grant model fails to recognize the different realities of core infrastructure vs application work. Protocol work
             needs ongoing funding streams, applications need revenue freedom. Current grant structures constrain both in perpetual dependency,
-            preventing the sustainability they aim to support.'
+            preventing the sustainability they aim to support. <SimpleShareButton shareId="one-size-fits-all" />'
         />
 
         <p>

--- a/src/app/components/research-report/conclusion.tsx
+++ b/src/app/components/research-report/conclusion.tsx
@@ -1,3 +1,5 @@
+import { SimpleShareButton } from "@/app/components/share-mode/simple-share-button";
+
 export const Conclusion = () => {
   return (
     <div className='font-inter text-lg flex flex-col gap-10'>
@@ -14,7 +16,7 @@ export const Conclusion = () => {
           The study was carried out independently, following research ethics standards: voluntary participation, informed consent, anonymity,
           confidentiality, and the right to withdraw. <br /> <br /> Our heartfelt thanks to the 26 contributors who shared their experiences,
           insights, and time with us. Their openness and generosity made this work possible, and will inform ongoing efforts to improve sustainability
-          in open-source Bitcoin and related freedom technologies.
+          in open-source Bitcoin and related freedom technologies. <SimpleShareButton shareId="sustainable-permissionlessness" />
         </p>
       </section>
     </div>

--- a/src/app/components/research-report/core-findings-the-tyrany/index.tsx
+++ b/src/app/components/research-report/core-findings-the-tyrany/index.tsx
@@ -1,4 +1,5 @@
 import { CrocAnimation } from "../croc-animation";
+import { SimpleShareButton } from "@/app/components/share-mode/simple-share-button";
 
 export const CoreFindingsTheTyrany = () => {
   return (
@@ -18,7 +19,7 @@ export const CoreFindingsTheTyrany = () => {
       </p>
       <strong>{`Permissionlessness — the defining principle of Bitcoin and the broader OSS ecosystem — becomes oppressive when applied to human work systems.`}</strong>
       <p>
-        We call this <strong>"the tyranny of permissionlessness."</strong>
+        We call this <strong>"the tyranny of permissionlessness."</strong> <SimpleShareButton shareId="permissionlessness-isolation" />
       </p>
     </section>
     </div>

--- a/src/app/components/research-report/from-tyranny-to-permissionlessness/sections-data.tsx
+++ b/src/app/components/research-report/from-tyranny-to-permissionlessness/sections-data.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { List, ListItem } from './list-components';
+import { SimpleShareButton } from '@/app/components/share-mode/simple-share-button';
 
 export interface Section {
   id: string;
@@ -13,7 +14,7 @@ export const sections: Section[] = [
     textContent: (
       <div className="max-w-3xl min-h-[200px] flex items-center text-base">
         <p className="mb-4">
-        Our findings revealed that the very freedom that attracts developers creates the conditions that drive them away — admin burden, isolation, grant anxiety. This "tyranny of permissionlessness" represents one possible, yet critical, failure mode of open, decentralized systems — not an inevitable outcome. While the funding ecosystem for Bitcoin and related technologies is expanding, there are several ways in which funders and stakeholders in the ecosystem can further support grant-funded contributors.
+        Our findings revealed that the very freedom that attracts developers creates the conditions that drive them away — admin burden, isolation, grant anxiety. This "tyranny of permissionlessness" represents one possible, yet critical, failure mode of open, decentralized systems — not an inevitable outcome. While the funding ecosystem for Bitcoin and related technologies is expanding, there are several ways in which funders and stakeholders in the ecosystem can further support grant-funded contributors. <SimpleShareButton shareId="not-inevitable" />
 
         </p>
       </div>
@@ -24,7 +25,7 @@ export const sections: Section[] = [
     id: "01",
     textContent: (
       <div className="max-w-3xl min-h-[200px] flex items-center text-base">
-        <p>These recommendations outline concrete steps toward "sustainable permissionlessness" — maintaining open participation while creating structural support for contributors' day-to-day experience. They are directed primarily to funders, since project maintainers and contributors are already bearing the full weight of the tyranny of permissionlessness.</p>
+        <p>These recommendations outline concrete steps toward "sustainable permissionlessness" — maintaining open participation while creating structural support for contributors' day-to-day experience. They are directed primarily to funders, since project maintainers and contributors are already bearing the full weight of the tyranny of permissionlessness. <SimpleShareButton shareId="keeping-open-participation" /></p>
       </div>
     ),
     animation: 'innerOnly',
@@ -48,7 +49,7 @@ export const sections: Section[] = [
         <div>
           <p className="uppercase font-bold mb-4">Restructure funding models</p>
           <List>
-            <ListItem>Fund teams, not just individuals: introduce team-oriented grants to support application layer developers.</ListItem>
+            <ListItem>Fund teams, not just individuals: introduce team-oriented grants to support application layer developers. <SimpleShareButton shareId="fund-teams-recommendation" /></ListItem>
             <ListItem>Learn from The FOSS Sustainability Fund which supports projects and "the communities that sustain them" through grants that can be awarded to organizations.</ListItem>
             <ListItem>Extend renewal cycles after year 1: reduce the grant-writing burden for proven contributors.</ListItem>
             <ListItem>Create revenue friendly grants: encourage profitability in grant-funded applications, based on OSS principles, use licensing cleverly to avoid corporate capture.</ListItem>
@@ -85,7 +86,7 @@ export const sections: Section[] = [
           <ListItem>Mental health resources: normalize and support initiatives aimed to improve contributors' psychological wellbeing.</ListItem>
           <ListItem>While community-led initiatives such as Open Source Guides provide general self-care tips for OSS maintainers, freedom tech developers face unique stressors. Funders could support tailored programs and resources that understand the specific challenges of building censorship-resistant infrastructure.</ListItem>
           <ListItem>Self-management toolkits: provide productivity resources, time management support, especially for newer contributors.</ListItem>
-          <ListItem>Make invisible work visible and valued: explicitly recognize and compensate non-coding work (research, maintenance, mentorship, documentation, management) in grant structures and community recognition systems.</ListItem>
+            <ListItem>Make invisible work visible and valued: explicitly recognize and compensate non-coding work (research, maintenance, mentorship, documentation, management) in grant structures and community recognition systems. <SimpleShareButton shareId="make-invisible-visible" /></ListItem>
         </List>
       </div>
     ),

--- a/src/app/components/research-report/strategies.tsx
+++ b/src/app/components/research-report/strategies.tsx
@@ -1,4 +1,5 @@
 import { QuoteCards } from "./_components/quotes";
+import { SimpleShareButton } from "@/app/components/share-mode/simple-share-button";
 
 export const Strategies = () => {
   return (
@@ -10,7 +11,7 @@ export const Strategies = () => {
 
         <p>
           The combination of openness and permissionless ethos, unstructured work environment, lack of support structures, and short-term funding
-          cycles results in a day-to-day routine marked by chaos, which contributors navigate in different ways.{" "}
+          cycles results in a day-to-day routine marked by chaos, which contributors navigate in different ways. <SimpleShareButton shareId="no-framework" />
         </p>
       </section>
 

--- a/src/app/components/research-report/study-overview-section/components/demographics.tsx
+++ b/src/app/components/research-report/study-overview-section/components/demographics.tsx
@@ -1,4 +1,5 @@
 import { DemographicsMap } from "../../_components/map-demographics";
+import { SimpleShareButton } from "@/app/components/share-mode/simple-share-button";
 
 export const Demographics = () => {
   return (
@@ -9,7 +10,7 @@ export const Demographics = () => {
         <section className='flex flex-col gap-12 text-xl justify-between h-full lg:max-w-[415px]'>
           <p>We interviewed participants from 10+ countries, spanning 5 continents.</p>
           <p>However, over half of our interviewees came from North America and Europe.</p>
-          <p>Two participants chose not to disclose their location.</p>
+          <p>Two participants chose not to disclose their location. <SimpleShareButton shareId="sustainability-challenges" /></p>
         </section>
 
         <DemographicsMap />

--- a/src/app/components/research-report/study-overview-section/components/our-research.tsx
+++ b/src/app/components/research-report/study-overview-section/components/our-research.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { SimpleShareButton } from "@/app/components/share-mode/simple-share-button";
 
 const researchOverviewNumbers = [
   {
@@ -76,7 +77,7 @@ export const OurResearch = () => {
 
       <p>
         Between March and May 2025, we interviewed 26 Bitcoin and Nostr contributors who had worked full-time on grant-funded projects for at
-        least 12 months. Through semi-structured interviews, we explored:
+        least 12 months. Through semi-structured interviews, we explored: <SimpleShareButton shareId="study-stats" />
       </p>
 
       <section className='grid grid-cols-1 md:grid-cols-2 gap-8 lg:gap-10'>

--- a/src/app/components/research-report/top-level-analysis.tsx
+++ b/src/app/components/research-report/top-level-analysis.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { useMediaQuery } from "@/hooks/window-dimensions";
 import ParadoxVisualization from "@/app/components/research-report/_components/nav-paradoxes-oss/index";
 import { ExperienceParadoxes } from "./_components/experience-the-paradoxes";
+import { SimpleShareButton } from "@/app/components/share-mode/simple-share-button";
 
 export const TopLevelAnalysis = () => {
   // const isMobile = useMediaQuery("(max-width: 768px)");
@@ -22,7 +23,7 @@ export const TopLevelAnalysis = () => {
           the closest to the first term, and 10 is closest to the second term).
         </p>
 
-        <p>Here are the results, highlighting common patterns and strongest polarizations.</p>
+        <p>Here are the results, highlighting common patterns and strongest polarizations. <SimpleShareButton shareId="sustainability-paradox" /></p>
       </section>
       <ParadoxVisualization />
       {/* {TOFIX: NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.} */}

--- a/src/app/components/research-report/tyranny-of-permissionlessness/index.tsx
+++ b/src/app/components/research-report/tyranny-of-permissionlessness/index.tsx
@@ -7,6 +7,7 @@ import { useRef } from "react";
 import { gsap } from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import { useGSAP } from "@gsap/react";
+import { SimpleShareButton } from "@/app/components/share-mode/simple-share-button";
 
 gsap.registerPlugin(ScrollTrigger);
 
@@ -83,7 +84,7 @@ export const TyrannyOfPermissionlessness = () => {
 
           <p>
             Below we describe these tensions. Each dimension shows how the very features that attract contributors to the space — mission, openness,
-            autonomy — become the primary causes of unsustainable work patterns.
+            autonomy — become the primary causes of unsustainable work patterns. <SimpleShareButton shareId="permissionlessness-enables" />
           </p>
         </section>
       </Wrapper>

--- a/src/app/components/share-mode/simple-share-button.tsx
+++ b/src/app/components/share-mode/simple-share-button.tsx
@@ -48,13 +48,12 @@ export const SimpleShareButton: React.FC<SimpleShareButtonProps> = ({
   return (
     <button
       onClick={handleClick}
-      className={`text-[11.28px] flex flex-row items-center gap-1 text-white font-inknutAntiqua text-nowrap h-[30px] px-2.5 rounded-lg bg-[#282F40] transition-all duration-150 hover:scale-105 active:scale-95 ${className}`}
+      className={`inline-flex items-center justify-center w-6 h-6 text-white rounded-full bg-[#282F40] transition-all duration-150 hover:scale-105 active:scale-95 ${className}`}
       title={content.title}
     >
       <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
         <path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92z"/>
       </svg>
-      Share
     </button>
   );
 };

--- a/src/app/initiatives/permissionless-paths/research-report/client.tsx
+++ b/src/app/initiatives/permissionless-paths/research-report/client.tsx
@@ -89,9 +89,6 @@ export function ResearchReportClient() {
                   support structures they lead developers to navigate unlimited responsibility alone. <strong>This isn't inevitable: with intentional design, we can maintain permissionless participation while building sustainable work
                   practices.</strong>
                 </span>
-                <div className="flex justify-center mt-8">
-                <SimpleShareButton shareId="free-from-authority" />
-              </div>
               </section>
               <p>The report unfolds in six parts:</p>
             


### PR DESCRIPTION
- Add SimpleShareButton components to key sections of the research report
- Modify SimpleShareButton to show only icon (no Share text) for cleaner design
- Position share buttons inline at end of relevant sentences
- Remove share buttons from Executive Summary section
- Add share buttons to: Study Overview, Demographics, Top-Level Analysis, Core Findings, Tyranny section, Strategies, Beyond Financial Sustainability, Recommendations, and Conclusion
- Each button corresponds to specific shareable content from the dataset