### PR TITLE
Fix folder layout with navbar height calculation

### DIFF
--- a/src/app/components/research-report/tyranny-of-permissionlessness/folders/animations/initial-state.ts
+++ b/src/app/components/research-report/tyranny-of-permissionlessness/folders/animations/initial-state.ts
@@ -33,7 +33,7 @@ export function setInitialState({ wrapper, folders, contents }: AnimationRefs) {
     folders.forEach((folder, i) => {
         gsap.set(folder, {
             ...INITIAL_STATE.folder,
-            zIndex: 100 + i,
+            zIndex: 200 + i,
         })
     })
 

--- a/src/app/components/research-report/tyranny-of-permissionlessness/folders/index.tsx
+++ b/src/app/components/research-report/tyranny-of-permissionlessness/folders/index.tsx
@@ -83,10 +83,17 @@ export const Folders = () => {
     const [tabLayout, setTabLayout] = useState(() =>
         calculateTabLayout(FOLDER_CONFIG.length, 1200)
     )
+    const [navbarHeight, setNavbarHeight] = useState(0)
 
     useEffect(() => {
         const updateLayout = () => {
             setTabLayout(calculateTabLayout(FOLDER_CONFIG.length, window.innerWidth * 0.92))
+
+            // Measure navbar height
+            const navbar = document.querySelector('nav')
+            if (navbar) {
+                setNavbarHeight(navbar.offsetHeight)
+            }
         }
 
         updateLayout()
@@ -183,6 +190,7 @@ export const Folders = () => {
                                 backgroundColor={config.backgroundColor}
                                 tabWidth={tabDimensions.width}
                                 tabLeftPosition={tabDimensions.leftPosition}
+                                navbarHeight={navbarHeight}
                                 onTabClick={() => handleTabClick(index)}
                             >
                                 <ContentComponent />


### PR DESCRIPTION
- Increase folder zIndex from 100 to 200
- Add navbarHeight prop to Folder component
- Calculate tab height based on tabWidth and aspect ratio
- Add responsive tab height calculation for mobile
- Position folder content below navbar with proper height calculation
- Add resize listener for dynamic tab height updates